### PR TITLE
fixed padding issue for always operator

### DIFF
--- a/stljax/formula.py
+++ b/stljax/formula.py
@@ -953,7 +953,7 @@ class Always(STL_Formula):
         elif padding == "mean":
             pad_value = signal.mean(time_dim)
         else:
-            pad_value = -large_number
+            pad_value = mask_value
         signal_pad = jnp.concatenate([jnp.ones([interval[1], T]) * sign * pad_value, jnp.ones([1, T]) * pad_value], axis=time_dim)
         signal_padded = jnp.concatenate([signal_matrix, signal_pad], axis=time_dim)
         subsignal_mask = jnp.tril(jnp.ones([T + interval[1]+1,T]))


### PR DESCRIPTION
There was an issue of inverting the sign of large number with padding for the always operator when padding is not specified explicitly. Since always' semantics take a min over time, this should be a large positive number. Fixed it by replacing with mask_value which is the correct sign.